### PR TITLE
Update script name in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN yum update -y \
 
 WORKDIR /scripts
 COPY install-pg-dump.sh .
-RUN "/scripts/install-pg_dump.sh"
+RUN "/scripts/install-pg-dump.sh"
 
 COPY backup.sh .
 ENTRYPOINT [ "/scripts/backup.sh" ]


### PR DESCRIPTION
- Previously, we updated the script name from `install-pg_dump.sh` to `install-pg-dump.sh`
- Let's update it inside the Dockerfile to fix `file not found` errors